### PR TITLE
Include license file in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
The terms of the license require all copies of the software include the license text